### PR TITLE
Feat: convert animation.bone.translatex/y/scalex/y/shearx/y to combined translate/scale/shear when downgrading 4.x → 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SpineSkeletonDataConverter.exe input.skel output.json
 SpineSkeletonDataConverter.exe input.json output.skel
 
 # Cross-version conversion (convert 3.7 file to 4.2 format)
-SpineSkeletonDataConverter.exe input37.json output42.json -v 4.2.11
+SpineSkeletonDataConverter.exe input37.json output42.json -v 4.2.11 --XYconvert
 
 # Convert new binary format to old version
 SpineSkeletonDataConverter.exe new.skel old.json -v 3.8.99
@@ -60,6 +60,7 @@ SpineSkeletonDataConverter.exe new.skel old.json -v 3.8.99
 # Options:
 #   -v              Output version (must be complete: x.y.z format)
 #   --remove-curve  Strip animation curves instead of converting when crossing 3.x/4.x
+#	--XYconvert		convert "animation.bone.translatex/translatey/scalex/scaley/shearx/sheary" to "animation.bone.translate/scale/shear" 			  when downgrading from 4.x to 3.x instead of removing them completely.
 #   --help          Show this help message
 
 # Supported Spine versions: 3.5.x, 3.6.x, 3.7.x, 3.8.x, 4.0.x, 4.1.x, 4.2.x
@@ -99,13 +100,15 @@ For large directories of Spine assets, use the bundled helper script `tools/Spin
 python tools/SpineConverter.py <input_dir> <output_dir> \
 	[-v x.y.z] \
 	[--format same|json|skel|other] \
-	[--remove-curve]
+	[--remove-curve] \
+	[--XYconvert]
 ```
 
 - Recursively processes `.json`, `.skel`, and `.atlas` files, preserving the folder structure in the output directory.
 - `-v` overrides the target skeleton version (defaults to each file's original version).
 - `--format` controls output formats for `.json`/`.skel` files (`same` keeps the original format, `json`/`skel` force a specific format, and `other` swaps between the two).
 - `--remove-curve` forwards to the native converter, stripping animation curves instead of translating them when converting between 3.x and 4.x.
+- `-XYconver` convert "animation.bone.translatex/translatey/scalex/scaley/shearx/sheary" to "animation.bone.translate/scale/shear" when downgrading from 4.x to 3.x instead of removing them completely.
 - `.atlas` files are always downgraded through `SpineAtlasDowngrade.exe`.
 
 ## 🧪 Testing

--- a/include/SkeletonData.h
+++ b/include/SkeletonData.h
@@ -613,6 +613,7 @@ namespace spine42 {
     Json writeJsonData(const SkeletonData&);
 }
 
+void mergeTranslateXYToTranslate(SkeletonData& skeleton); // "<translate/scale/shear>x" + "<translate/scale/shear>y" = "<translate/scale/shear>"
 void convertCurve3xTo4x(SkeletonData& skeleton);
 void convertCurve4xTo3x(SkeletonData& skeleton);
 void removeCurve(SkeletonData& skeleton);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,6 +220,9 @@ bool convertFile(const std::string& inputFile, const std::string& outputFile,
         // 跨版本转换处理
         if (aboveOrEqualVersion(inputVersion, SpineVersion::Version40) &&
             belowOrEqualVersion(outputVersion, SpineVersion::Version38)) {
+
+            //combine "translatex" and "translatey" into "translate" (similar to scaleXY and shearXY) before doing the downgrade
+            mergeTranslateXYToTranslate(skelData); 
             if (removeCurveOption) {
                 std::cout << "Converting from 4.x to 3.x with --remove-curve, stripping curves...\n";
                 removeCurve(skelData);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -416,6 +416,7 @@ void printUsage(const char* programName) {
     std::cout << "Options:\n";
     std::cout << "  -v          Output version (must be complete: x.y.z format)\n";
     std::cout << "  --remove-curve  Strip animation curves instead of converting between formats\n";
+    std::cout << "  --XYconvert  convert \"animation.bone.translatex/translatey/scalex/scaley/shearx/sheary\" to \"animation.bone.translate/scale/shear\" when downgrading from 4.x to 3.x instead of removing them completely.\n";
     std::cout << "  --help      Show this help message\n\n";
     std::cout << "Examples:\n";
     std::cout << "  " << programName << " input.skel output.json\n";


### PR DESCRIPTION
##Summary

Description:

Added a feature to automatically convert Spine 4.x animation properties
animation.bone.translatex/translatey/scalex/scaley/shearx/sheary
→ into combined forms animation.bone.translate/scale/shear when downgrading to Spine 3.x, instead of removing them.

Added the --XYconvert option to enable this conversion.

##Why

Spine 3.x does not support animation.bone.translatex/translatey/scalex/scaley/shearx/sheary,
so when downgrading from 4.x to 3.x, these properties were previously discarded.
As a result, animations using these attributes would lose part of their motion, requiring users to manually edit and fix them.
This feature converts the separated attributes into combined forms (translate/scale/shear),
helping preserve the original motion more accurately.

##Notes

The conversion can only approximate the original motion and may require fine-tuning for precise results.

In practice, very few animations use translatex/translatey/scalex/scaley/shearx/sheary, or they appear only occasionally.

Verified that downgrading from Spine 4.1.24 → 3.8.75 produces valid output that runs correctly in the runtime.
