### PR TITLE
Fix: Collect attachment names referenced in animations for string table

### DIFF
--- a/src/SkeletonData38BinaryWriter.cpp
+++ b/src/SkeletonData38BinaryWriter.cpp
@@ -552,6 +552,26 @@ Binary writeBinaryData(SkeletonData& skeletonData) {
     for (const EventData& event : skeletonData.events) {
         strings.insert(event.name);
     }
+    // Collect attachment names referenced in animations
+    for (const Animation& animation : skeletonData.animations) {
+        // Collect attachment names from slot attachment timelines
+        for (const auto& [slotName, multiTimeline] : animation.slots) {
+            if (multiTimeline.contains("attachment")) {
+                const auto& timeline = multiTimeline.at("attachment");
+                for (const auto& frame : timeline) {
+                    if (frame.str1) strings.insert(frame.str1.value());
+                }
+            }
+        }
+        // Collect attachment names from deform/sequence animations
+        for (const auto& [skinName, skinMap] : animation.attachments) {
+            for (const auto& [slotName, slotMap] : skinMap) {
+                for (const auto& [attachmentName, multiTimeline] : slotMap) {
+                    strings.insert(attachmentName);
+                }
+            }
+        }
+    }
     writeVarint(binary, strings.size(), true);
     skeletonData.strings.clear();
     for (const std::string& str : strings) {

--- a/src/SkeletonData40BinaryWriter.cpp
+++ b/src/SkeletonData40BinaryWriter.cpp
@@ -598,6 +598,26 @@ Binary writeBinaryData(SkeletonData& skeletonData) {
     for (const EventData& event : skeletonData.events) {
         strings.insert(event.name);
     }
+    // Collect attachment names referenced in animations
+    for (const Animation& animation : skeletonData.animations) {
+        // Collect attachment names from slot attachment timelines
+        for (const auto& [slotName, multiTimeline] : animation.slots) {
+            if (multiTimeline.contains("attachment")) {
+                const auto& timeline = multiTimeline.at("attachment");
+                for (const auto& frame : timeline) {
+                    if (frame.str1) strings.insert(frame.str1.value());
+                }
+            }
+        }
+        // Collect attachment names from deform animations
+        for (const auto& [skinName, skinMap] : animation.attachments) {
+            for (const auto& [slotName, slotMap] : skinMap) {
+                for (const auto& [attachmentName, multiTimeline] : slotMap) {
+                    strings.insert(attachmentName);
+                }
+            }
+        }
+    }
     writeVarint(binary, strings.size(), true);
     skeletonData.strings.clear();
     for (const std::string& str : strings) {

--- a/src/SkeletonData41BinaryWriter.cpp
+++ b/src/SkeletonData41BinaryWriter.cpp
@@ -628,6 +628,26 @@ Binary writeBinaryData(SkeletonData& skeletonData) {
     for (const EventData& event : skeletonData.events) {
         strings.insert(event.name);
     }
+    // Collect attachment names referenced in animations
+    for (const Animation& animation : skeletonData.animations) {
+        // Collect attachment names from slot attachment timelines
+        for (const auto& [slotName, multiTimeline] : animation.slots) {
+            if (multiTimeline.contains("attachment")) {
+                const auto& timeline = multiTimeline.at("attachment");
+                for (const auto& frame : timeline) {
+                    if (frame.str1) strings.insert(frame.str1.value());
+                }
+            }
+        }
+        // Collect attachment names from deform/sequence animations
+        for (const auto& [skinName, skinMap] : animation.attachments) {
+            for (const auto& [slotName, slotMap] : skinMap) {
+                for (const auto& [attachmentName, multiTimeline] : slotMap) {
+                    strings.insert(attachmentName);
+                }
+            }
+        }
+    }
     writeVarint(binary, strings.size(), true);
     skeletonData.strings.clear();
     for (const std::string& str : strings) {

--- a/src/SkeletonData42BinaryWriter.cpp
+++ b/src/SkeletonData42BinaryWriter.cpp
@@ -741,6 +741,26 @@ Binary writeBinaryData(SkeletonData& skeletonData) {
             }
         }
     }
+    // Collect attachment names referenced in animations
+    for (const Animation& animation : skeletonData.animations) {
+        // Collect attachment names from slot attachment timelines
+        for (const auto& [slotName, multiTimeline] : animation.slots) {
+            if (multiTimeline.contains("attachment")) {
+                const auto& timeline = multiTimeline.at("attachment");
+                for (const auto& frame : timeline) {
+                    if (frame.str1) strings.insert(frame.str1.value());
+                }
+            }
+        }
+        // Collect attachment names from deform/sequence animations
+        for (const auto& [skinName, skinMap] : animation.attachments) {
+            for (const auto& [slotName, slotMap] : skinMap) {
+                for (const auto& [attachmentName, multiTimeline] : slotMap) {
+                    strings.insert(attachmentName);
+                }
+            }
+        }
+    }
     writeVarint(binary, strings.size(), true);
     skeletonData.strings.clear();
     for (const std::string& str : strings) {


### PR DESCRIPTION
## 问题描述

在写入二进制文件时，Spine 使用字符串表机制来优化存储。所有被引用的字符串需要在文件开头的字符串表中声明，后续通过索引引用。

原有代码在收集字符串时存在遗漏：
- ✅ 已收集：slot 默认 attachment、skin 中的 attachment、event 名称
- ❌ 遗漏：动画中引用的 attachment 名称
  - `animation.slots.attachment` timeline 中的 attachment 引用
  - `animation.attachments` (deform/sequence) 中的 attachment 名称

这会导致报错：
```bash
Error during conversion: String reference not found: Meat_Head_R_2_D1
```

## 修复内容

在字符串收集阶段增加对动画中 attachment 引用的收集：

1. **收集 slot attachment timeline 中的引用**
   - 遍历所有动画的 slot timelines
   - 提取 attachment timeline 中的 attachment 名称

2. **收集 deform/sequence 动画中的 attachment 名称**
   - 遍历所有动画的 attachments 数据
   - 提取所有被引用的 attachment 名称

## 影响版本

- ✅ 3.8 (SkeletonData38BinaryWriter.cpp)
- ✅ 4.0 (SkeletonData40BinaryWriter.cpp)
- ✅ 4.1 (SkeletonData41BinaryWriter.cpp)
- ✅ 4.2 (SkeletonData42BinaryWriter.cpp)

> **注意：** 3.7 及更早版本不使用字符串表机制，无需修复。

## 测试

从 [p0001_Lily.zip](https://github.com/f14XuanLv/EnderLilies-More-Skins-Modding-Toolkit/blob/main/templates/p0001_Lily.zip) 解压出 `p0001_Lily.atlas` 和 `p0001_Lily.skel`

在项目源码目录下创建 `p0001_Lily_3.8.99` 文件夹 和 `test_conv_fix.bat` 测试脚本，如下所示：

```
SpineSkeletonDataConverter/
├── data/
├── include/
├── spine/
├── p0001_Lily_3.8.99/
│   ├── p0001_Lily.atlas # .atlas 放在这
│   └── p0001_Lily.skel # .skel 放在这
├── src/
├── tools/
├── .gitignore
├── 版本差异记录.md
├── CMakeLists.txt
├── README.md
├── LICENSE
└── test_conv_fix.bat # 测试脚本
```

`test_conv_fix.bat` 测试脚本内容如下
```bat
@echo off
REM ============================================================================
REM Test script for animation attachment string reference fix
REM Tests conversion from Spine 3.8.99 to multiple 4.x versions
REM ============================================================================

REM Set converter executable path
set CONVERTER_EXE=build\Release\SpineSkeletonDataConverter.exe

REM Check if converter executable exists
if not exist "%CONVERTER_EXE%" (
    echo.
    echo ============================================================================
    echo ERROR: Converter executable not found!
    echo Expected location: %CONVERTER_EXE%
    echo.
    echo Please read README.md and compile the project first.
    echo ============================================================================
    echo.
    exit /b 1
)

echo.
echo Starting conversion tests...
echo.

REM Create output directory if it doesn't exist
if not exist "skel_test_output" (
    echo Creating output directory: skel_test_output
    mkdir skel_test_output
)

REM Test 1: Convert to Spine 3.8.99 (same version)
echo [1/4] Converting to Spine 3.8.99...
%CONVERTER_EXE% p0001_Lily_3.8.99\p0001_Lily.skel skel_test_output\p0001_Lily_3899.skel -v 3.8.99
if errorlevel 1 (
    echo ERROR: Failed to convert to 3.8.99
    goto :error
)
echo SUCCESS: Converted to 3.8.99
echo.

REM Test 2: Convert to Spine 4.0.64
echo [2/4] Converting to Spine 4.0.64...
%CONVERTER_EXE% p0001_Lily_3.8.99\p0001_Lily.skel skel_test_output\p0001_Lily_4064.skel -v 4.0.64
if errorlevel 1 (
    echo ERROR: Failed to convert to 4.0.64
    goto :error
)
echo SUCCESS: Converted to 4.0.64
echo.

REM Test 3: Convert to Spine 4.1.24
echo [3/4] Converting to Spine 4.1.24...
%CONVERTER_EXE% p0001_Lily_3.8.99\p0001_Lily.skel skel_test_output\p0001_Lily_4124.skel -v 4.1.24
if errorlevel 1 (
    echo ERROR: Failed to convert to 4.1.24
    goto :error
)
echo SUCCESS: Converted to 4.1.24
echo.

REM Test 4: Convert to Spine 4.2.43
echo [4/4] Converting to Spine 4.2.43...
%CONVERTER_EXE% p0001_Lily_3.8.99\p0001_Lily.skel skel_test_output\p0001_Lily_4243.skel -v 4.2.43
if errorlevel 1 (
    echo ERROR: Failed to convert to 4.2.43
    goto :error
)
echo SUCCESS: Converted to 4.2.43
echo.

echo ============================================================================
echo All conversions completed successfully!
echo Output directory: skel_test_output
echo ============================================================================
goto :end

:error
echo.
echo ============================================================================
echo Conversion test failed! Please check the error messages above.
echo ============================================================================
exit /b 1

:end
```

如果应用该 fix , 则报错问题解决，可成功完成版本转换