### PR TITLE
Platform-aware executable search in `SpineConverter.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .vscode
-build
+build/
 test_examples
+CMakeFiles/
+lib/
+*.cmake
+bin/
+CMakeCache.txt
+Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(SpineSkeletonDataConverter)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Output directory: bin/ for executables, lib/ for static libraries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
+
 # Add spine-c/spine-cpp for syntax prompting. These won't be linked to the final executable.
 # Comment out if you don't need syntax prompting.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd SpineSkeletonDataConverter
 mkdir build && cd build
 
 # Configure and build
-cmake ..
+cmake .
 cmake --build . --config Release
 ```
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,5 +1,5 @@
 #include "SkeletonData.h"
-
+#include <sstream>
 // json reader
 
 Color stringToColor(const std::string& str, bool hasAlpha) {

--- a/tools/SpineConverter.py
+++ b/tools/SpineConverter.py
@@ -9,17 +9,40 @@ def format_command(command: list[str]) -> str:
 
 
 def locate_executable(name: str) -> Path:
+	# Search from tools/ up to project root
 	script_dir = Path(__file__).resolve().parent
-	direct_candidate = script_dir / name
-	if direct_candidate.exists():
-		return direct_candidate
+	project_root = script_dir.parent.parent  # tools/ -> project root
 
-	for candidate in script_dir.rglob(name):
-		if candidate.is_file():
-			return candidate
+	# Detect platform
+	is_windows = sys.platform == "win32"
+	windows_name = f"{name}.exe"
+
+	# Platform-specific search order
+	# Windows: name.exe -> name
+	# macOS/Linux: name -> name.exe
+	if is_windows:
+		search_order = [windows_name, name]
+	else:
+		search_order = [name, windows_name]
+
+	# Search locations: tools/, project root bin/
+	search_dirs = [script_dir,  project_root / "bin"]
+
+	# Check direct candidate in each directory
+	for search_dir in search_dirs:
+		for candidate_name in search_order:
+			direct_candidate = search_dir / candidate_name
+			if direct_candidate.exists():
+				return direct_candidate
+
+	# Recursive search in project root
+	for candidate_name in search_order:
+		for candidate in project_root.rglob(candidate_name):
+			if candidate.is_file():
+				return candidate
 
 	raise FileNotFoundError(
-		f"Could not locate {name} under {script_dir}. Ensure the executable is placed alongside this script."
+		f"Could not locate {name} under {project_root}. Ensure the executable is built and placed in the project root or build/ directory."
 	)
 
 
@@ -62,8 +85,8 @@ def process_files(args: argparse.Namespace) -> None:
 
 	output_dir.mkdir(parents=True, exist_ok=True)
 
-	converter_exe = locate_executable("SpineSkeletonDataConverter.exe")
-	atlas_exe = locate_executable("SpineAtlasDowngrade.exe")
+	converter_exe = locate_executable("SpineSkeletonDataConverter")
+	atlas_exe = locate_executable("SpineAtlasDowngrade")
 
 	for path in input_dir.rglob("*"):
 		if not path.is_file():


### PR DESCRIPTION
  - `build/bin/` for executables
  - `build/lib/` for static libraries (.a)
- Platform-aware executable search in `SpineConverter.py`:
  - Windows: prefer `name.exe` first
  - macOS/Linux: prefer no extension first
- Added `#include <sstream>` to `common.cpp`