### PR TITLE
feat: 将Atlas的scale参数处理移动至skel中，实现无损4→3降级

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,18 +161,26 @@ void applyAtlasScale(SkeletonData& data, double scale) {
                     auto& mesh = std::get<MeshAttachment>(attachment.data);
                     mesh.width *= scaleF;
                     mesh.height *= scaleF;
-                    // Mesh vertices 格式：
-                    // 如果是加权网格：[boneCount, boneIdx, weight, x, y, ...] 循环
-                    // 只缩放 x, y 坐标，不缩放 boneCount, boneIdx, weight
-                    size_t i = 0;
-                    while (i < mesh.vertices.size()) {
-                        int boneCount = static_cast<int>(mesh.vertices[i]); // 不缩放
-                        i++; // 跳过 boneCount
-                        for (int j = 0; j < boneCount && i < mesh.vertices.size(); j++) {
-                            i++; // 跳过 bone index（不缩放）
-                            i++; // 跳过 weight（不缩放）
-                            if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // x 坐标
-                            if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // y 坐标
+                    // 判断是否加权网格：vertices.size() > uvs.size() 表示加权
+                    bool weighted = mesh.vertices.size() > mesh.uvs.size();
+                    if (weighted) {
+                        // 加权网格：[boneCount, boneIdx, weight, x, y, ...] 循环
+                        // 只缩放 x, y 坐标
+                        size_t i = 0;
+                        while (i < mesh.vertices.size()) {
+                            int boneCount = static_cast<int>(mesh.vertices[i]);
+                            i++;
+                            for (int j = 0; j < boneCount && i < mesh.vertices.size(); j++) {
+                                i++; // bone index
+                                i++; // weight
+                                if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // x
+                                if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // y
+                            }
+                        }
+                    } else {
+                        // 非加权网格：[x, y, x, y, ...] 直接缩放所有坐标
+                        for (size_t i = 0; i < mesh.vertices.size(); i++) {
+                            mesh.vertices[i] *= scaleF;
                         }
                     }
                     break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ struct ConversionOptions {
     std::string outputVersionString; // 完整的版本号字符串，如 "4.2.11"
     bool help = false;
     bool removeCurve = false;
+    double atlasScale = 1.0; // Atlas scale 因子，用于将 atlas 的缩放转移到 skel 数据中
 };
 
 bool aboveOrEqualVersion(SpineVersion version, SpineVersion target) {
@@ -121,11 +122,50 @@ SpineVersion parseVersionString(const std::string& versionStr) {
     return SpineVersion::Invalid;
 }
 
+void applyAtlasScale(SkeletonData& data, double scale) {
+    if (std::abs(scale - 1.0) < 1e-9) return;
+
+    float scaleF = static_cast<float>(scale);
+
+    for (auto& skin : data.skins) {
+        for (auto& [slotName, attachments] : skin.attachments) {
+            for (auto& [attachName, attachment] : attachments) {
+                switch (attachment.type) {
+                case AttachmentType_Region: {
+                    auto& region = std::get<RegionAttachment>(attachment.data);
+                    region.scaleX *= scaleF;
+                    region.scaleY *= scaleF;
+                    break;
+                }
+                case AttachmentType_Mesh: {
+                    auto& mesh = std::get<MeshAttachment>(attachment.data);
+                    mesh.width *= scaleF;
+                    mesh.height *= scaleF;
+                    break;
+                }
+                case AttachmentType_Linkedmesh: {
+                    auto& linkedMesh = std::get<LinkedmeshAttachment>(attachment.data);
+                    linkedMesh.width *= scaleF;
+                    linkedMesh.height *= scaleF;
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    data.width *= scaleF;
+    data.height *= scaleF;
+}
+
 bool convertFile(const std::string& inputFile, const std::string& outputFile, 
                 FileFormat inputFormat, FileFormat outputFormat, 
                 SpineVersion inputVersion, SpineVersion outputVersion, 
                 const std::string& outputVersionString,
-                bool removeCurveOption) {
+                bool removeCurveOption,
+                double atlasScale) {
     
     try {
         // Read input file
@@ -244,6 +284,13 @@ bool convertFile(const std::string& inputFile, const std::string& outputFile,
             belowOrEqualVersion(outputVersion, SpineVersion::Version41)) {
             std::cout << "Converting from 4.2 to below 4.2, adjusting constraint order...\n"; 
             convertOrder42ToBelow(skelData);
+        }
+        
+        // 应用 Atlas scale 因子到 skel 数据
+        if (std::abs(atlasScale - 1.0) >= 1e-9) {
+            std::cout << "Applying atlas scale factor " << atlasScale << " to skeleton data...\n";
+            applyAtlasScale(skelData, atlasScale);
+            std::cout << "NOTE: Please use original atlas images WITHOUT scaling.\n";
         }
         
         // Write data using output version
@@ -407,9 +454,10 @@ void printUsage(const char* programName) {
     std::cout << "  .json       Spine JSON format\n";
     std::cout << "  .skel       Spine binary (SKEL) format\n\n";
     std::cout << "Options:\n";
-    std::cout << "  -v          Output version (must be complete: x.y.z format)\n";
-    std::cout << "  --remove-curve  Strip animation curves instead of converting between formats\n";
-    std::cout << "  --help      Show this help message\n\n";
+    std::cout << "  -v                 Output version (must be complete: x.y.z format)\n";
+    std::cout << "  --remove-curve     Strip animation curves instead of converting between formats\n";
+    std::cout << "  --atlas-scale <v>  Apply atlas scale factor to skel data (avoids image resizing precision loss)\n";
+    std::cout << "  --help             Show this help message\n\n";
     std::cout << "Examples:\n";
     std::cout << "  " << programName << " input.skel output.json\n";
     std::cout << "  " << programName << " input.json output.skel\n";
@@ -479,6 +527,22 @@ ConversionOptions parseArguments(int argc, char* argv[]) {
             options.help = true;
         } else if (arg == "--remove-curve") {
             options.removeCurve = true;
+        } else if (arg == "--atlas-scale") {
+            if (i + 1 < argc) {
+                try {
+                    options.atlasScale = std::stod(argv[++i]);
+                    if (options.atlasScale <= 0.0) {
+                        std::cerr << "Error: --atlas-scale must be positive\n";
+                        options.help = true;
+                    }
+                } catch (...) {
+                    std::cerr << "Error: Invalid value for --atlas-scale\n";
+                    options.help = true;
+                }
+            } else {
+                std::cerr << "Error: --atlas-scale requires a numeric argument\n";
+                options.help = true;
+            }
         } else {
             std::cerr << "Warning: Unknown option: " << arg << "\n";
         }
@@ -531,7 +595,7 @@ int main(int argc, char* argv[]) {
         std::cout << "Converting from " << (options.inputFormat == FileFormat::Json ? "JSON" : "SKEL") 
                   << " to " << (options.outputFormat == FileFormat::Json ? "JSON" : "SKEL") << "...\n";
         
-        if (convertFile(options.inputFile, options.outputFile, options.inputFormat, options.outputFormat, inputVersion, outputVersion, outputVersionString, options.removeCurve)) {
+        if (convertFile(options.inputFile, options.outputFile, options.inputFormat, options.outputFormat, inputVersion, outputVersion, outputVersionString, options.removeCurve, options.atlasScale)) {
             std::cout << "Conversion completed successfully!\n";
             std::cout << "Output file: " << options.outputFile << "\n";
             return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,12 +126,21 @@ void applyAtlasScale(SkeletonData& data, double scale) {
     if (std::abs(scale - 1.0) < 1e-9) return;
 
     float scaleF = static_cast<float>(scale);
+    float invScaleF = 1.0f / scaleF;  // 反向缩放因子，用于根骨骼和整体尺寸
 
     // 缩放骨骼位置（x/y 和 length）
     for (auto& bone : data.bones) {
         bone.x *= scaleF;
         bone.y *= scaleF;
         bone.length *= scaleF;
+    }
+
+    // 根骨骼（没有父骨骼的骨骼）应用反向缩放，整体放大恢复到设计尺寸
+    for (auto& bone : data.bones) {
+        if (!bone.parent.has_value()) {
+            bone.scaleX *= invScaleF;
+            bone.scaleY *= invScaleF;
+        }
     }
 
     for (auto& skin : data.skins) {
@@ -198,8 +207,9 @@ void applyAtlasScale(SkeletonData& data, double scale) {
         }
     }
 
-    data.width *= scaleF;
-    data.height *= scaleF;
+    // Skeleton 整体尺寸恢复到设计尺寸（反向缩放）
+    data.width *= invScaleF;
+    data.height *= invScaleF;
 }
 
 bool convertFile(const std::string& inputFile, const std::string& outputFile, 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,17 +126,19 @@ void applyAtlasScale(SkeletonData& data, double scale) {
     if (std::abs(scale - 1.0) < 1e-9) return;
 
     float scaleF = static_cast<float>(scale);
-    float invScaleF = 1.0f / scaleF;  // 反向缩放因子，用于根骨骼和整体尺寸
+    float invScaleF = 1.0f / scaleF;
 
-    // 缩放骨骼位置（x/y 和 length）
-    for (auto& bone : data.bones) {
+    // 缩放骨骼位置
+    for (size_t i = 0; i < data.bones.size(); i++) {
+        auto& bone = data.bones[i];
         bone.x *= scaleF;
         bone.y *= scaleF;
         bone.length *= scaleF;
     }
 
-    // 根骨骼（没有父骨骼的骨骼）应用反向缩放，整体放大恢复到设计尺寸
-    for (auto& bone : data.bones) {
+    // 根骨骼反向缩放
+    for (size_t i = 0; i < data.bones.size(); i++) {
+        auto& bone = data.bones[i];
         if (!bone.parent.has_value()) {
             bone.scaleX *= invScaleF;
             bone.scaleY *= invScaleF;
@@ -159,8 +161,19 @@ void applyAtlasScale(SkeletonData& data, double scale) {
                     auto& mesh = std::get<MeshAttachment>(attachment.data);
                     mesh.width *= scaleF;
                     mesh.height *= scaleF;
-                    for (size_t i = 0; i < mesh.vertices.size(); i++) {
-                        mesh.vertices[i] *= scaleF;
+                    // Mesh vertices 格式：
+                    // 如果是加权网格：[boneCount, boneIdx, weight, x, y, ...] 循环
+                    // 只缩放 x, y 坐标，不缩放 boneCount, boneIdx, weight
+                    size_t i = 0;
+                    while (i < mesh.vertices.size()) {
+                        int boneCount = static_cast<int>(mesh.vertices[i]); // 不缩放
+                        i++; // 跳过 boneCount
+                        for (int j = 0; j < boneCount && i < mesh.vertices.size(); j++) {
+                            i++; // 跳过 bone index（不缩放）
+                            i++; // 跳过 weight（不缩放）
+                            if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // x 坐标
+                            if (i < mesh.vertices.size()) mesh.vertices[i++] *= scaleF; // y 坐标
+                        }
                     }
                     break;
                 }
@@ -172,25 +185,33 @@ void applyAtlasScale(SkeletonData& data, double scale) {
                 }
                 case AttachmentType_Boundingbox: {
                     auto& bbox = std::get<BoundingboxAttachment>(attachment.data);
-                    for (size_t i = 0; i < bbox.vertices.size(); i++) {
-                        bbox.vertices[i] *= scaleF;
+                    if (!bbox.vertices.empty()) {
+                        for (size_t i = 0; i < bbox.vertices.size(); i++) {
+                            bbox.vertices[i] *= scaleF;
+                        }
                     }
                     break;
                 }
                 case AttachmentType_Path: {
                     auto& path = std::get<PathAttachment>(attachment.data);
-                    for (size_t i = 0; i < path.vertices.size(); i++) {
-                        path.vertices[i] *= scaleF;
+                    if (!path.vertices.empty()) {
+                        for (size_t i = 0; i < path.vertices.size(); i++) {
+                            path.vertices[i] *= scaleF;
+                        }
                     }
-                    for (size_t i = 0; i < path.lengths.size(); i++) {
-                        path.lengths[i] *= scaleF;
+                    if (!path.lengths.empty()) {
+                        for (size_t i = 0; i < path.lengths.size(); i++) {
+                            path.lengths[i] *= scaleF;
+                        }
                     }
                     break;
                 }
                 case AttachmentType_Clipping: {
                     auto& clipping = std::get<ClippingAttachment>(attachment.data);
-                    for (size_t i = 0; i < clipping.vertices.size(); i++) {
-                        clipping.vertices[i] *= scaleF;
+                    if (!clipping.vertices.empty()) {
+                        for (size_t i = 0; i < clipping.vertices.size(); i++) {
+                            clipping.vertices[i] *= scaleF;
+                        }
                     }
                     break;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,26 +127,68 @@ void applyAtlasScale(SkeletonData& data, double scale) {
 
     float scaleF = static_cast<float>(scale);
 
+    // 缩放骨骼位置（x/y 和 length）
+    for (auto& bone : data.bones) {
+        bone.x *= scaleF;
+        bone.y *= scaleF;
+        bone.length *= scaleF;
+    }
+
     for (auto& skin : data.skins) {
         for (auto& [slotName, attachments] : skin.attachments) {
             for (auto& [attachName, attachment] : attachments) {
                 switch (attachment.type) {
                 case AttachmentType_Region: {
                     auto& region = std::get<RegionAttachment>(attachment.data);
-                    region.scaleX *= scaleF;
-                    region.scaleY *= scaleF;
+                    region.x *= scaleF;
+                    region.y *= scaleF;
+                    region.width *= scaleF;
+                    region.height *= scaleF;
                     break;
                 }
                 case AttachmentType_Mesh: {
                     auto& mesh = std::get<MeshAttachment>(attachment.data);
                     mesh.width *= scaleF;
                     mesh.height *= scaleF;
+                    for (size_t i = 0; i < mesh.vertices.size(); i++) {
+                        mesh.vertices[i] *= scaleF;
+                    }
                     break;
                 }
                 case AttachmentType_Linkedmesh: {
                     auto& linkedMesh = std::get<LinkedmeshAttachment>(attachment.data);
                     linkedMesh.width *= scaleF;
                     linkedMesh.height *= scaleF;
+                    break;
+                }
+                case AttachmentType_Boundingbox: {
+                    auto& bbox = std::get<BoundingboxAttachment>(attachment.data);
+                    for (size_t i = 0; i < bbox.vertices.size(); i++) {
+                        bbox.vertices[i] *= scaleF;
+                    }
+                    break;
+                }
+                case AttachmentType_Path: {
+                    auto& path = std::get<PathAttachment>(attachment.data);
+                    for (size_t i = 0; i < path.vertices.size(); i++) {
+                        path.vertices[i] *= scaleF;
+                    }
+                    for (size_t i = 0; i < path.lengths.size(); i++) {
+                        path.lengths[i] *= scaleF;
+                    }
+                    break;
+                }
+                case AttachmentType_Clipping: {
+                    auto& clipping = std::get<ClippingAttachment>(attachment.data);
+                    for (size_t i = 0; i < clipping.vertices.size(); i++) {
+                        clipping.vertices[i] *= scaleF;
+                    }
+                    break;
+                }
+                case AttachmentType_Point: {
+                    auto& point = std::get<PointAttachment>(attachment.data);
+                    point.x *= scaleF;
+                    point.y *= scaleF;
                     break;
                 }
                 default:

--- a/tools/Spine4xTo38Converter.py
+++ b/tools/Spine4xTo38Converter.py
@@ -8,9 +8,14 @@ This tool implements 3 main tasks:
 2. Convert 4.x atlas to 3.8 format and extract page->scale mapping
 3. Scale PNG images according to the scale mapping
 
+Modes:
+  - Default: Scale PNG images, apply scale to atlas coordinates (integer, lossy)
+  - --lossless: Keep original PNG, apply scale to skel float data (lossless)
+
 Usage:
     python Spine4xTo38Converter.py input.skel output_dir --converter path/to/SpineSkeletonDataConverter.exe
     python Spine4xTo38Converter.py input.json output_dir --converter path/to/SpineSkeletonDataConverter.exe
+    python Spine4xTo38Converter.py input.skel output_dir --converter path/to/SpineSkeletonDataConverter.exe --lossless
 """
 
 import os
@@ -27,7 +32,7 @@ from PIL import Image
 # Task 1: Skeleton Data Conversion
 # ============================================================================
 
-def convert_skeleton_data(input_file: str, output_file: str, converter_path: str) -> bool:
+def convert_skeleton_data(input_file: str, output_file: str, converter_path: str, atlas_scale: float = 1.0) -> bool:
     """任务1：使用SpineSkeletonDataConverter转换skeleton数据"""
     try:
         cmd = [
@@ -36,6 +41,8 @@ def convert_skeleton_data(input_file: str, output_file: str, converter_path: str
             output_file,
             '-v', '3.8.75'
         ]
+        if atlas_scale != 1.0:
+            cmd.extend(['--atlas-scale', str(atlas_scale)])
         
         print(f"Converting skeleton: {os.path.basename(input_file)}")
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -221,17 +228,22 @@ def read_atlas_data_4x(content: str) -> AtlasData:
     return atlas_data
 
 
-def write_atlas_data_38(atlas_data: AtlasData) -> str:
-    """子任务2.2：写入3.8格式atlas，应用scale到各个数值"""
+def write_atlas_data_38(atlas_data: AtlasData, ignore_scale: bool = False) -> str:
+    """子任务2.2：写入3.8格式atlas
+    
+    Args:
+        atlas_data: Atlas数据对象
+        ignore_scale: True时保持原始坐标不变（仅移除scale参数），False时应用scale到坐标
+    """
     output_lines = []
     
     for page in atlas_data.pages:
-        # 页面名称
         output_lines.append(page.name)
         
-        # size (必需) - 应用scale
-        width = int(page.width / page.scale) if page.scale != 1.0 else page.width
-        height = int(page.height / page.scale) if page.scale != 1.0 else page.height
+        scale = page.scale if not ignore_scale else 1.0
+        
+        width = int(page.width / scale) if scale != 1.0 else page.width
+        height = int(page.height / scale) if scale != 1.0 else page.height
         output_lines.append(f"size: {width}, {height}")
         
         # format (必需)
@@ -257,42 +269,36 @@ def write_atlas_data_38(atlas_data: AtlasData) -> str:
                 output_lines.append(f"  rotate: {region.degrees}")
             
             # xy (必需) - 应用scale
-            x = int(region.x / page.scale) if page.scale != 1.0 else region.x
-            y = int(region.y / page.scale) if page.scale != 1.0 else region.y
+            x = int(region.x / scale) if scale != 1.0 else region.x
+            y = int(region.y / scale) if scale != 1.0 else region.y
             output_lines.append(f"  xy: {x}, {y}")
             
             # size (必需) - 应用scale
-            width = int(region.width / page.scale) if page.scale != 1.0 else region.width
-            height = int(region.height / page.scale) if page.scale != 1.0 else region.height
-            output_lines.append(f"  size: {width}, {height}")
+            r_width = int(region.width / scale) if scale != 1.0 else region.width
+            r_height = int(region.height / scale) if scale != 1.0 else region.height
+            output_lines.append(f"  size: {r_width}, {r_height}")
             
             # split (可选，仅当存在时) - 应用scale
             if region.splits and len(region.splits) >= 4:
-                if page.scale != 1.0:
-                    splits = [str(int(s / page.scale)) for s in region.splits[:4]]
-                else:
-                    splits = [str(s) for s in region.splits[:4]]
+                splits = [str(int(s / scale)) if scale != 1.0 else str(s) for s in region.splits[:4]]
                 output_lines.append(f"  split: {', '.join(splits)}")
             
             # pad (可选，仅当存在split时) - 应用scale
             if region.pads and len(region.pads) >= 4:
-                if page.scale != 1.0:
-                    pads = [str(int(p / page.scale)) for p in region.pads[:4]]
-                else:
-                    pads = [str(p) for p in region.pads[:4]]
+                pads = [str(int(p / scale)) if scale != 1.0 else str(p) for p in region.pads[:4]]
                 output_lines.append(f"  pad: {', '.join(pads)}")
             
             # orig (必需) - 应用scale
             orig_width = region.original_width if region.original_width > 0 else region.width
             orig_height = region.original_height if region.original_height > 0 else region.height
-            if page.scale != 1.0:
-                orig_width = int(orig_width / page.scale)
-                orig_height = int(orig_height / page.scale)
+            if scale != 1.0:
+                orig_width = int(orig_width / scale)
+                orig_height = int(orig_height / scale)
             output_lines.append(f"  orig: {orig_width}, {orig_height}")
             
             # offset (必需) - 应用scale
-            offset_x = int(region.offset_x / page.scale) if page.scale != 1.0 else region.offset_x
-            offset_y = int(region.offset_y / page.scale) if page.scale != 1.0 else region.offset_y
+            offset_x = int(region.offset_x / scale) if scale != 1.0 else region.offset_x
+            offset_y = int(region.offset_y / scale) if scale != 1.0 else region.offset_y
             output_lines.append(f"  offset: {offset_x}, {offset_y}")
             
             # index (必需)
@@ -323,10 +329,9 @@ def convert_atlas_4x_to_38(atlas_content: str) -> tuple[str, AtlasData]:
 # Task 3: Image Scaling - 使用atlasData中的scale信息
 # ============================================================================
 
-def scale_png_images(atlas_data: AtlasData, atlas_dir: str, output_dir: str):
-    """任务3：根据atlasData中的scale信息缩放PNG图片文件"""
+def scale_png_images(atlas_data: AtlasData, atlas_dir: str, output_dir: str, lossless: bool = False):
+    """任务3：根据atlasData中的scale信息处理PNG图片"""
     for page in atlas_data.pages:
-        # 处理页面名称中可能包含的路径
         png_name = os.path.basename(page.name)
         if png_name.endswith('.png'):
             png_name = png_name[:-4]
@@ -338,10 +343,9 @@ def scale_png_images(atlas_data: AtlasData, atlas_dir: str, output_dir: str):
             print(f"  ✗ PNG file not found: {png_name}.png")
             continue
         
-        if page.scale == 1.0:
-            # 不需要缩放，直接复制
+        if lossless or page.scale == 1.0:
             shutil.copy2(input_path, output_path)
-            print(f"  ✓ Copied {png_name}.png (scale=1.0, no scaling needed)")
+            print(f"  ✓ Copied {png_name}.png (original size)")
         else:
             # 需要缩放
             try:
@@ -351,8 +355,7 @@ def scale_png_images(atlas_data: AtlasData, atlas_dir: str, output_dir: str):
                     
                     scaled_img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
                     scaled_img.save(output_path)
-                    print(f"  ✓ Scaled {png_name}.png: {img.width}x{img.height} → {new_width}x{new_height} (scale={page.scale})")
-                    
+                    print(f"  ✓ Scaled {png_name}.png: {img.width}x{img.height} → {new_width}x{new_height}")
             except Exception as e:
                 print(f"  ✗ Error scaling {png_name}.png: {e}")
 
@@ -380,6 +383,7 @@ def main():
     parser.add_argument('input_file', help='Input skeleton file (.skel or .json)')
     parser.add_argument('output_dir', help='Output directory for converted files')
     parser.add_argument('--converter', required=True, help='Path to SpineSkeletonDataConverter executable')
+    parser.add_argument('--lossless', action='store_true', help='Lossless mode: keep original PNG, apply scale to skel')
     
     args = parser.parse_args()
     
@@ -402,50 +406,47 @@ def main():
     
     print(f"Converting Spine 4.x project: {input_path.name}")
     print(f"Output directory: {args.output_dir}")
+    print(f"Mode: {'lossless' if args.lossless else 'default (scale PNG)'}")
     print("-" * 50)
     
     success = True
     
-    # ============================================================================
-    # 任务1：转换skeleton数据
-    # ============================================================================
-    output_skeleton = os.path.join(args.output_dir, f"{base_name}.json")
-    if not convert_skeleton_data(args.input_file, output_skeleton, args.converter):
-        success = False
-    
-    # ============================================================================
-    # 任务2：转换atlas文件
-    # ============================================================================
     atlas_file = find_atlas_file(args.input_file)
+    atlas_scale = 1.0
+    
     if atlas_file:
         print(f"Found atlas file: {os.path.basename(atlas_file)}")
-        
-        # 读取4.x atlas内容
         with open(atlas_file, 'r', encoding='utf-8') as f:
             atlas_4x_content = f.read()
+        atlas_data = read_atlas_data_4x(atlas_4x_content)
         
-        # 转换到3.8格式并获取atlas数据
-        atlas_38_content, atlas_data = convert_atlas_4x_to_38(atlas_4x_content)
+        if atlas_data.pages:
+            atlas_scale = atlas_data.pages[0].scale
+            print(f"Atlas scale: {atlas_scale}")
         
-        # 保存转换后的atlas文件
-        output_atlas = os.path.join(args.output_dir, f"{base_name}.atlas")
-        with open(output_atlas, 'w', encoding='utf-8') as f:
-            f.write(atlas_38_content)
-        print(f"✓ Atlas conversion successful")
-        
-        # 打印scale信息
-        print(f"Found {len(atlas_data.pages)} pages:")
-        for page in atlas_data.pages:
-            print(f"  {page.name}: scale={page.scale}")
-        
-        # ============================================================================
-        # 任务3：根据atlasData缩放PNG图片
-        # ============================================================================
-        print("Processing PNG images:")
-        scale_png_images(atlas_data, atlas_dir, args.output_dir)
-        
+        if args.lossless:
+            output_atlas = os.path.join(args.output_dir, f"{base_name}.atlas")
+            atlas_38_content = write_atlas_data_38(atlas_data, ignore_scale=True)
+            with open(output_atlas, 'w', encoding='utf-8') as f:
+                f.write(atlas_38_content)
+            print(f"✓ Atlas converted (scale removed, coordinates unchanged)")
+        else:
+            atlas_38_content, _ = convert_atlas_4x_to_38(atlas_4x_content)
+            output_atlas = os.path.join(args.output_dir, f"{base_name}.atlas")
+            with open(output_atlas, 'w', encoding='utf-8') as f:
+                f.write(atlas_38_content)
+            print(f"✓ Atlas converted (scale applied to coordinates)")
     else:
         print("Warning: No atlas file found")
+    
+    output_ext = input_path.suffix
+    output_skeleton = os.path.join(args.output_dir, f"{base_name}{output_ext}")
+    if not convert_skeleton_data(args.input_file, output_skeleton, args.converter, atlas_scale if args.lossless else 1.0):
+        success = False
+    
+    if atlas_file and atlas_data.pages:
+        print("Processing PNG images:")
+        scale_png_images(atlas_data, atlas_dir, args.output_dir, args.lossless)
     
     print("-" * 50)
     if success:

--- a/tools/SpineAtlasDowngrade.py
+++ b/tools/SpineAtlasDowngrade.py
@@ -178,16 +178,19 @@ def read_atlas_data_4x(content: str) -> AtlasData:
     
     return atlas_data
 
-def write_atlas_data_3x(atlas_data: AtlasData) -> str:
+def write_atlas_data_3x(atlas_data: AtlasData, ignore_scale: bool = False) -> str:
     """Generates a 3.x compatible atlas string from an AtlasData object."""
     output_lines = []
     
     for page in atlas_data.pages:
         output_lines.append(page.name)
         
-        # Apply scale to page size
-        width = int(page.width / page.scale) if page.scale != 1.0 else page.width
-        height = int(page.height / page.scale) if page.scale != 1.0 else page.height
+        # Apply scale to page size (unless ignored)
+        if ignore_scale or page.scale == 1.0:
+            width, height = page.width, page.height
+        else:
+            width = int(page.width / page.scale)
+            height = int(page.height / page.scale)
         output_lines.append(f"size: {width}, {height}")
         
         output_lines.append(f"format: {page.format}")
@@ -205,8 +208,8 @@ def write_atlas_data_3x(atlas_data: AtlasData) -> str:
             else:
                 output_lines.append(f"  rotate: {region.degrees}")
             
-            # Apply scale to all region metrics
-            scale = page.scale
+            # Apply scale to all region metrics (unless ignored)
+            scale = page.scale if not ignore_scale else 1.0
             x = int(region.x / scale) if scale != 1.0 else region.x
             y = int(region.y / scale) if scale != 1.0 else region.y
             output_lines.append(f"  xy: {x}, {y}")
@@ -246,7 +249,7 @@ def write_atlas_data_3x(atlas_data: AtlasData) -> str:
 # Image Scaling
 # ============================================================================
 
-def scale_png_images(atlas_data: AtlasData, atlas_dir: Path, output_dir: Path):
+def scale_png_images(atlas_data: AtlasData, atlas_dir: Path, output_dir: Path, ignore_scale: bool = False):
     """Scales PNG texture images based on the scale property in the atlas data."""
     print("Processing PNG images:")
     for page in atlas_data.pages:
@@ -258,9 +261,10 @@ def scale_png_images(atlas_data: AtlasData, atlas_dir: Path, output_dir: Path):
             print(f"  ✗ PNG file not found: {input_path}")
             continue
         
-        if page.scale == 1.0:
+        if ignore_scale or page.scale == 1.0:
             shutil.copy2(input_path, output_path)
-            print(f"  ✓ Copied {png_name} (scale=1.0, no scaling needed)")
+            mode_desc = " (scale ignored)" if ignore_scale else " (scale=1.0, no scaling needed)"
+            print(f"  ✓ Copied {png_name}{mode_desc}")
         else:
             try:
                 with Image.open(input_path) as img:
@@ -281,6 +285,8 @@ def main():
     parser = argparse.ArgumentParser(description='Convert Spine 4.x atlas to 3.x format.')
     parser.add_argument('input_atlas', help='Input 4.x atlas file')
     parser.add_argument('output_dir', help='Output directory for converted files')
+    parser.add_argument('--ignore-scale', action='store_true',
+                        help='Ignore scale property: copy images without resizing and keep original coordinates. ')
     
     args = parser.parse_args()
     
@@ -295,6 +301,8 @@ def main():
     
     print(f"Converting Spine 4.x atlas: {input_path.name}")
     print(f"Output directory: {output_dir}")
+    if args.ignore_scale:
+        print("Mode: IGNORE SCALE (images will be copied, coordinates kept as-is)")
     print("-" * 50)
     
     # Read 4.x atlas content
@@ -305,7 +313,7 @@ def main():
     atlas_data = read_atlas_data_4x(atlas_4x_content)
     
     # Generate 3.x atlas content
-    atlas_3x_content = write_atlas_data_3x(atlas_data)
+    atlas_3x_content = write_atlas_data_3x(atlas_data, ignore_scale=args.ignore_scale)
     
     # Save the converted atlas file
     output_atlas_path = output_dir / input_path.name
@@ -315,7 +323,7 @@ def main():
     
     # Scale the associated PNG images
     atlas_dir = input_path.parent
-    scale_png_images(atlas_data, atlas_dir, output_dir)
+    scale_png_images(atlas_data, atlas_dir, output_dir, ignore_scale=args.ignore_scale)
     
     print("-" * 50)
     print("✓ Atlas downgrade completed successfully!")


### PR DESCRIPTION
## 功能：--atlas-scale 参数实现

相关issue： https://github.com/wang606/SpineSkeletonDataConverter/issues/20  https://github.com/wang606/SpineSkeletonDataConverter/issues/28

声明：代码是我vibe出来的，我确实不太懂spine内部格式，但是我用手头的素材测试了一下可以正常使用。
至于有没有更好的实现方法我就不清楚了233

保留了原方案为默认方案，新实现的无损转换功能通过`--atlas-scale`参数开启。

下方的报告也是AI代写

### 背景

Spine 4.x Atlas 支持 scale 参数（如 scale: 0.6 或 1.27），Spine 3.x 不支持。
传统降级方案通过缩放 PNG 图像处理，导致像素精度损失。

### 方案
将 Atlas scale 操作转移到 Skel 文件的浮点数据转换中，实现无损转换。

### 实现细节

`applyAtlasScale(SkeletonData& data, double scale)` 函数处理以下数据：

1. **骨骼位置**：`bone.x`, `bone.y`, `bone.length` × scale
2. **根骨骼反向缩放**：`root.scaleX`, `root.scaleY` × (1/scale)，恢复设计尺寸
3. **Region Attachment**：`x`, `y`, `width`, `height` × scale
4. **Mesh Attachment**：
   - `width`, `height` × scale
   - `vertices` 处理：
     - 加权网格：`[boneCount, boneIdx, weight, x, y, ...]` 循环格式，只缩放 x, y 坐标
     - 非加权网格：`[x, y, x, y, ...]` 直接缩放所有坐标
5. **Linked Mesh / Bounding Box / Path**：相应数据 × scale
6. **Skeleton 尺寸**：`width`, `height` × (1/scale)

### 使用方式

**方式一：Python 脚本**

```bash
# 无损模式：保留原图，scale 应用到 skel 浮点数据
python Spine4xTo38Converter.py input.skel output_dir --converter converter.exe --lossless

# 默认模式：缩放 PNG，scale 应用到 atlas 整数坐标（有损）
python Spine4xTo38Converter.py input.skel output_dir --converter converter.exe
```

**方式二：手动调用**

```bash
# C++ 程序
SpineSkeletonDataConverter input.skel output.skel --atlas-scale 0.75

# Atlas 降级（移除 scale 参数，保持坐标不变）
python SpineAtlasDowngrade.py input.atlas output_dir --ignore-scale
```

### 文件更新

- `src/main.cpp`：添加 `applyAtlasScale()` 函数和 `--atlas-scale` 参数
- `tools/Spine4xTo38Converter.py`：添加 `--lossless` 模式，集成 atlas scale 处理逻辑
- `tools/SpineAtlasDowngrade.py`：添加 `--ignore-scale` 参数