### PR TITLE
修复 4.2 版本 mesh weighted 标志误判导致生成的 skel 文件损坏

### DIFF
--- a/src/SkeletonData42BinaryWriter.cpp
+++ b/src/SkeletonData42BinaryWriter.cpp
@@ -175,7 +175,7 @@ void writeSkin(Binary& binary, const Skin& skin, const SkeletonData& skeletonDat
                     if (attachment.path != attachment.name) flags |= 16;
                     if (mesh.color) flags |= 32;
                     if (mesh.sequence) flags |= 64;
-                    if (mesh.vertices.size() > mesh.uvs.size()) flags |= 128;
+                    if (mesh.vertices.size() != mesh.uvs.size()) flags |= 128;
                     break; 
                 }
                 case AttachmentType_Linkedmesh: {


### PR DESCRIPTION
## 问题描述

`SpineSkeletonDataConverter` 在将某些 Spine 4.2 JSON 文件转换为 `.skel` 时，会生成**损坏的 skel 文件**。该文件不仅无法被重新转回 JSON，也无法被 Spine 官方运行时正确加载。

典型表现为：JSON → SKEL → JSON 往返转换时，第二步会崩溃并报错：

```
Error during conversion: vector too long
```

## 复现步骤

1. 使用[122018.json](https://github.com/user-attachments/files/29203131/122018.json)（Spine 4.2）。

2. 执行：

   ```bash
   SpineSkeletonDataConverter.exe 122018.json 122018.skel
   SpineSkeletonDataConverter.exe 122018.skel 122018_back.json
   ```

3. 第二条命令失败，报错 `vector too long`。

## 根因分析

问题出在 `src/SkeletonData42BinaryWriter.cpp` 中对 mesh 是否 weighted 的判断：

```cpp
if (mesh.vertices.size() > mesh.uvs.size()) flags |= 128;
```

在附件的 `22018_79` 这个 mesh 上：

- `uvs` 长度 = 62（对应 31 个顶点）
- `vertices` 长度 = 31

该 mesh 实际上是一个 **weighted mesh**，但每个顶点的 `boneCount = 0`，导致 `vertices` 数组只包含 bone-count 占位数据，长度小于 `uvs`。旧的判断因此把它误判为 **unweighted**，写入了一个错误的 `vertexCount`（15 而不是 31）。生成的 skel 文件后续字段全部错位，`hullLength` 被读成了 31，导致 triangles 数量计算为负数：

```cpp
(vertexCount * 2 - hullLength - 2) * 3  // -> -9
```

随后 `readShortArray` 尝试 `resize(-9)`，抛出 `vector too long`。

## 修复方案

将 weighted 判断条件由 `>` 改为 `!=`：

```cpp
if (mesh.vertices.size() != mesh.uvs.size()) flags |= 128;
```

对于 unweighted mesh，`vertices` 和 `uvs` 长度必然相等（都是 `2 * vertexCount`）。只要两者长度不同，就说明使用了 weighted 顶点格式。

## 验证结果

修复后执行：

```bash
SpineSkeletonDataConverter.exe 122018.json 122018.skel
SpineSkeletonDataConverter.exe 122018.skel 122018_back.json
```

两次转换均成功，且用 `tools/json_diff.py` 对比往返后的 JSON 与原始文件：

```
✅ 文件相同 (在指定容差范围内)
```

## 改动文件

- `src/SkeletonData42BinaryWriter.cpp`