### PR TITLE
Fix: 4.x→3.x 贝塞尔曲线转换浮点噪声导致动画抖动

### DIFF
--- a/src/CurveConverter.cpp
+++ b/src/CurveConverter.cpp
@@ -53,10 +53,13 @@ void convertBezierCurve3xTo4x(BezierCurve& bezier) {
 void convertBezierCurve4xTo3x(BezierCurve& bezier) {
     float timeRange = bezier.x2 - bezier.x1;
     float valueRange = bezier.y2 - bezier.y1;
-    bezier.cx1 = timeRange ? (bezier.cx1 - bezier.x1) / timeRange : 0.0f;
-    bezier.cy1 = valueRange ? (bezier.cy1 - bezier.y1) / valueRange : 0.0f;
-    bezier.cx2 = timeRange ? (bezier.cx2 - bezier.x1) / timeRange : 1.0f;
-    bezier.cy2 = valueRange ? (bezier.cy2 - bezier.y1) / valueRange : 1.0f;
+    // 当 timeRange/valueRange 极小时，归一化会产生极端值（如浮点噪声导致的 7.6e-16），
+    // 需要用阈值保护而非仅检查非零
+    constexpr float epsilon = 0.0001f;
+    bezier.cx1 = std::fabs(timeRange) > epsilon ? (bezier.cx1 - bezier.x1) / timeRange : 0.0f;
+    bezier.cy1 = std::fabs(valueRange) > epsilon ? (bezier.cy1 - bezier.y1) / valueRange : 0.0f;
+    bezier.cx2 = std::fabs(timeRange) > epsilon ? (bezier.cx2 - bezier.x1) / timeRange : 1.0f;
+    bezier.cy2 = std::fabs(valueRange) > epsilon ? (bezier.cy2 - bezier.y1) / valueRange : 1.0f;
 }
 
 void convertTimelineCurve3xTo4x(Timeline& timeline, std::vector<CurveYType> curveYTypes) {
@@ -150,6 +153,7 @@ void convertTimelineCurve4xTo3x(Timeline& timeline, CurveYType curveYType) {
             frame.curve[1] = bezier.cy1;
             frame.curve[2] = bezier.cx2;
             frame.curve[3] = bezier.cy2;
+            frame.curve.resize(4); // 4.x 多分量曲线可能有8+元素，3.x 只需4个
         }
     }
 }


### PR DESCRIPTION
# Fix: 4.x→3.x 贝塞尔曲线转换浮点噪声导致动画抖动

问题文件：
[ch0242_home.zip](https://github.com/user-attachments/files/29438008/ch0242_home.zip)

## 问题描述

Spine 4.2 骨骼动画降级到 3.8 格式后，原本静止的动画（Idle_01）出现上下浮动。使用 `--remove-curve` 参数则表现正常。

## 根因分析

`convertBezierCurve4xTo3x` 将 4.x 的绝对坐标贝塞尔曲线转换为 3.x 的归一化坐标时，使用 `valueRange`（帧间值差）作为除数进行归一化：

```cpp
bezier.cy1 = valueRange ? (bezier.cy1 - bezier.y1) / valueRange : 0.0f;
```

当骨骼的某个分量值几乎不变时（如 X 从 0 变到 7.6e-16），`valueRange` 极小但不为零，除法产生极端归一化值。实测数据：

| 字段 | 修复前 | 修复后 |
|------|--------|--------|
| cy1 | -103.48 | 0.0 |
| cy2 | 104.48 | 1.0 |

这导致贝塞尔插值进度范围从正常的 [0, 1] 飙升到 [-77, +46]，Y 方向插值严重偏离，产生可见的上下浮动。

## 修复方案

在 `convertBezierCurve4xTo3x` 中，用 epsilon 阈值替代简单的非零检查。当 `timeRange` 或 `valueRange` 极小时，将归一化结果钳位到合理默认值（cx1→0, cy1→0, cx2→1, cy2→1），等价于线性插值。

## 改动

### `src/CurveConverter.cpp`

**1. epsilon 阈值保护（主修复）**

```cpp
// 修复前
bezier.cx1 = timeRange ? (bezier.cx1 - bezier.x1) / timeRange : 0.0f;
bezier.cy1 = valueRange ? (bezier.cy1 - bezier.y1) / valueRange : 0.0f;
bezier.cx2 = timeRange ? (bezier.cx2 - bezier.x1) / timeRange : 1.0f;
bezier.cy2 = valueRange ? (bezier.cy2 - bezier.y1) / valueRange : 1.0f;

// 修复后
constexpr float epsilon = 0.0001f;
bezier.cx1 = std::fabs(timeRange) > epsilon ? (bezier.cx1 - bezier.x1) / timeRange : 0.0f;
bezier.cy1 = std::fabs(valueRange) > epsilon ? (bezier.cy1 - bezier.y1) / valueRange : 0.0f;
bezier.cx2 = std::fabs(timeRange) > epsilon ? (bezier.cx2 - bezier.x1) / timeRange : 1.0f;
bezier.cy2 = std::fabs(valueRange) > epsilon ? (bezier.cy2 - bezier.y1) / valueRange : 1.0f;
```

**2. curve 向量截断（附带修复）**

4.x 多分量时间线（如 translate）的 curve 向量有 8 个元素，转换到 3.x 后只需前 4 个。添加 `frame.curve.resize(4)` 确保 3.5/3.6/3.7 JSON writer 不会写出多余的 8 元素数组。

## 验证

- 数据验证：修复前 All_Layer/translate 的曲线归一化值为 `(0.3333, -103.48, 0.6667, -102.48)`，cy1/cy2 严重超出 [0,1] 范围；修复后修正为 `(0.3333, 0.0, 0.6667, 1.0)`，符合 3.x 归一化贝塞尔的合法范围
- 人工确认：修复后的 3.8 skel/json 文件在运行时播放正常，无上下浮动

- 编译后二进制文件：见 [[tag/fix-curve-epsilon-noise](https://github.com/Agent-0808/SpineSkeletonDataConverter/releases/tag/fix-curve-epsilon-noise)]